### PR TITLE
fix: implementa controles no mobile, ajusta cores e resolve FOUC de loading

### DIFF
--- a/index.html
+++ b/index.html
@@ -17,43 +17,45 @@
     :root {
       font-size: 16px;
     }
+    [x-cloak] {
+      display: none !important;
+    }
   </style>
 </head>
 
 <body>
-<div x-data x-show="$store.i18n.isLoading"
-  class="fixed inset-0 z-50 flex items-center justify-center bg-neutral-900 transition-opacity duration-300">
-  <div class="text-white text-xl font-bold flex flex-col items-center gap-4">
-    <i class="fa-solid fa-circle-notch fa-spin text-4xl text-[var(--green)]"></i>
-    <span>Carregando sistema...</span>
+
+<div x-data x-cloak x-show="!$store.i18n.isLoading" x-transition.opacity.duration.500ms>
+  <div x-data="{ content: '' }"
+    x-init="fetch('src/sections/header.html').then(res => res.text()).then(html => content = html)" x-html="content">
+  </div>
+  
+  <div x-data="{ content: '' }"
+    x-init="fetch('src/sections/hero.html').then(res => res.text()).then(html => content = html)" x-html="content">
+  </div>
+
+  <div class="max-w-7xl w-full mx-auto">
+    <div x-data="{ content: '' }"
+      x-init="fetch('src/sections/about.html').then(res => res.text()).then(html => content = html)" x-html="content">
+    </div>
+    <div x-data="{ content: '' }"
+      x-init="fetch('src/sections/cards.html').then(res => res.text()).then(html => content = html)" x-html="content">
+    </div>
+    <div x-data="{ content: '' }"
+      x-init="fetch('src/sections/faq.html').then(res => res.text()).then(html => content = html)" x-html="content">
+    </div>
+    <div x-data="{ content: '' }"
+      x-init="fetch('src/sections/team.html').then(res => res.text()).then(html => content = html)" x-html="content">
+    </div>
+    <div x-data="{ content: '' }"
+      x-init="fetch('src/sections/contact.html').then(res => res.text()).then(html => content = html)" x-html="content">
+    </div>
+    <div x-data="{ content: '' }"
+      x-init="fetch('src/sections/footer.html').then(res => res.text()).then(html => content = html)" x-html="content">
+    </div>
   </div>
 </div>
 
-<div x-data="{ content: '' }"
-  x-init="fetch('src/sections/header.html').then(res => res.text()).then(html => content = html)" x-html="content">
-</div>
-<div x-data="{ content: '' }"
-  x-init="fetch('src/sections/hero.html').then(res => res.text()).then(html => content = html)" x-html="content"></div>
-
-<div class="max-w-7xl w-full mx-auto">
-  <div x-data="{ content: '' }"
-    x-init="fetch('src/sections/about.html').then(res => res.text()).then(html => content = html)" x-html="content">
-  </div>
-  <div x-data="{ content: '' }"
-    x-init="fetch('src/sections/cards.html').then(res => res.text()).then(html => content = html)" x-html="content">
-  </div>
-  <div x-data="{ content: '' }"
-    x-init="fetch('src/sections/faq.html').then(res => res.text()).then(html => content = html)" x-html="content"></div>
-  <div x-data="{ content: '' }"
-    x-init="fetch('src/sections/team.html').then(res => res.text()).then(html => content = html)" x-html="content">
-  </div>
-  <div x-data="{ content: '' }"
-    x-init="fetch('src/sections/contact.html').then(res => res.text()).then(html => content = html)" x-html="content">
-  </div>
-  <div x-data="{ content: '' }"
-    x-init="fetch('src/sections/footer.html').then(res => res.text()).then(html => content = html)" x-html="content">
-  </div>
-</div>
 </body>
 
 <script>

--- a/src/sections/header.html
+++ b/src/sections/header.html
@@ -34,20 +34,20 @@
 
                         <div x-show="dropOpen"
                              x-transition.opacity
-                             class="absolute right-0 top-full mt-1 w-40 rounded-lg bg-neutral-900/90 backdrop-blur-lg border border-neutral-700 shadow-lg overflow-hidden z-50">
+                             class="absolute right-0 top-full mt-1 w-40 rounded-lg bg-neutral-900/90 backdrop-blur-lg border border-neutral-700 shadow-lg overflow-hidden z-50 cursor-pointer">
 
-                            <div class="py-1 flex flex-col">
-                                <button @click="$store.i18n.setLang('pt')" class="px-4 py-2 flex gap-3">
+                            <div class="py-1 flex flex-col ">
+                                <button @click="$store.i18n.setLang('pt')" class="px-4 py-2 flex gap-3 text-white cursor-pointer">
                                     <img src="assets/icon/brazil.svg" class="w-6 h-6">
                                     Português
                                 </button>
 
-                                <button @click="$store.i18n.setLang('en')" class="px-4 py-2 flex gap-3">
+                                <button @click="$store.i18n.setLang('en')" class="px-4 py-2 flex gap-3 text-white cursor-pointer">
                                     <img src="assets/icon/us.svg" class="w-6 h-6">
                                     English
                                 </button>
 
-                                <button @click="$store.i18n.setLang('es')" class="px-4 py-2 flex gap-3">
+                                <button @click="$store.i18n.setLang('es')" class="px-4 py-2 flex gap-3 text-white cursor-pointer">
                                     <img src="assets/icon/spain.svg" class="w-6 h-6">
                                     Español
                                 </button>
@@ -68,10 +68,10 @@
                         <i class="fa-solid fa-circle-half-stroke"></i>
                     </button>
 
-                    <a href="#hero" x-text="$store.i18n.t('nav.home')" class="px-3 py-2"></a>
-                    <a href="#about" x-text="$store.i18n.t('nav.about')" class="px-3 py-2"></a>
-                    <a href="#faq" x-text="$store.i18n.t('nav.faq')" class="px-3 py-2"></a>
-                    <a href="#contact" x-text="$store.i18n.t('nav.contact')" class="bg-[var(--green)] px-3 py-2 rounded-lg"></a>
+                    <a href="#hero" x-text="$store.i18n.t('nav.home')" class="px-3 py-2 text-white"></a>
+                    <a href="#about" x-text="$store.i18n.t('nav.about')" class="px-3 py-2 text-white"></a>
+                    <a href="#faq" x-text="$store.i18n.t('nav.faq')" class="px-3 py-2 text-white"></a>
+                    <a href="#contact" x-text="$store.i18n.t('nav.contact')" class="bg-[var(--green)] px-3 py-2 rounded-lg text-white"></a>
                 </div>
 
                 <button @click="menuOpen = !menuOpen"
@@ -84,13 +84,38 @@
 
         <div x-show="menuOpen"
              x-transition
-             class="bg-neutral-900/50 p-3 rounded-lg text-white backdrop-blur-lg sm:hidden">
+             class="bg-neutral-900/50 p-3 flex flex-col gap-2 rounded-lg text-white backdrop-blur-lg sm:hidden">
 
             <a href="#hero" x-text="$store.i18n.t('nav.home')" class="block px-2 py-1"></a>
             <a href="#about" x-text="$store.i18n.t('nav.about')" class="block px-2 py-1"></a>
             <a href="#faq" x-text="$store.i18n.t('nav.faq')" class="block px-2 py-1"></a>
             <a href="#contact" x-text="$store.i18n.t('nav.contact')" class="block px-2 py-1 bg-[var(--green)] rounded"></a>
 
+            <hr class="border-neutral-700 my-2">
+
+            <div class="flex justify-between items-center px-2 py-1">
+                
+                <div class="flex gap-3">
+                    <button @click="$store.i18n.setLang('pt')" class="hover:scale-110 transition">
+                        <img src="assets/icon/brazil.svg" class="w-6 h-6">
+                    </button>
+                    <button @click="$store.i18n.setLang('en')" class="hover:scale-110 transition">
+                        <img src="assets/icon/us.svg" class="w-6 h-6">
+                    </button>
+                    <button @click="$store.i18n.setLang('es')" class="hover:scale-110 transition">
+                        <img src="assets/icon/spain.svg" class="w-6 h-6">
+                    </button>
+                </div>
+
+                <div class="flex gap-2">
+                    <button onclick="changeFontSize(2)" class="px-2 py-1 bg-neutral-800 hover:bg-neutral-700 rounded text-sm">A+</button>
+                    <button onclick="changeFontSize(-2)" class="px-2 py-1 bg-neutral-800 hover:bg-neutral-700 rounded text-sm">A-</button>
+                    <button @click="highContrast = !highContrast" class="px-2 py-1 bg-neutral-800 hover:bg-neutral-700 rounded">
+                        <i class="fa-solid fa-circle-half-stroke"></i>
+                    </button>
+                </div>
+                
+            </div>
         </div>
 
     </div>


### PR DESCRIPTION
- Adiciona botões de idioma e ferramentas de acessibilidade ao menu responsivo (menuOpen) no header para dispositivos mobile.
- Altera a cor dos textos de navegação da navbar para branco.
- Implementa a diretiva x-cloak associada ao $store.i18n.isLoading para manter o lazy loading sem flash de conteúdo não estilizado.